### PR TITLE
Add enableGranularConsent parameter

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -147,6 +147,9 @@ Strategy.prototype.authorizationParams = function(options) {
   if (options.includeGrantedScopes) {
     params['include_granted_scopes'] = true;
   }
+  if (options.enableGranularConsent) {
+    params['enable_granular_consent'] = true;
+  }
   
   // https://developers.google.com/identity/protocols/OpenIDConnect
   if (options.display) {


### PR DESCRIPTION
The PR adds a new parameter in the options of the library. The parameter is the `enableGranularConsent`. This parameter will add the `enable_granular_consent` query param in the initial google auth call. 

When this param `enable_granular_consent=true` then google will enable the granular scopes for the call. This param will no have any affect after 17-Aug, where the granular scopes will be always on.